### PR TITLE
add spatialite_init_ex entry point for libspatialite.so

### DIFF
--- a/spatialite.go
+++ b/spatialite.go
@@ -15,6 +15,7 @@ type entrypoint struct {
 var LibNames = []entrypoint{
 	{"mod_spatialite", "sqlite3_modspatialite_init"},
 	{"libspatialite.so", "sqlite3_modspatialite_init"},
+	{"libspatialite.so", "spatialite_init_ex"},
 }
 
 var ErrSpatialiteNotFound = errors.New("shaxbee/go-spatialite: spatialite extension not found.")


### PR DESCRIPTION
It turns out that under Linux the entrypoint for libspatialite is `spatialite_init_ex`. See also:

https://github.com/mattn/go-sqlite3/issues/516